### PR TITLE
Generalised email SMTP settings but defaulting to Sendgrid.

### DIFF
--- a/msc/settings.py
+++ b/msc/settings.py
@@ -258,13 +258,13 @@ LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
 
-# Sendgrid Api
+# Email SMTP Provider e.g. Sendgrid
 
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_HOST_USER = 'apikey'
-EMAIL_HOST_PASSWORD = env('SENDGRID_API_KEY')
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
+EMAIL_HOST = env('EMAIL_HOST', default='smtp.sendgrid.net')
+EMAIL_HOST_USER = env('EMAIL_HOST_USER', default='apikey')
+EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
+EMAIL_PORT = env('EMAIL_PORT', default=587)
+EMAIL_USE_TLS = env('EMAIL_USE_TLS', default=True)
 
 # Localhost
 # EMAIL_HOST = 'localhost'


### PR DESCRIPTION
`SENDGRID_API_KEY` environment is no longer used, replace with `EMAIL_HOST_PASSWORD`. You can keep using Sendgrid and the rest of the defaults will work with Sendgrid.